### PR TITLE
Mark intro as required

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 Standards:
   -
     Title: Intro To Lightning Talks
-    Description: Intro To Lightning Talks
+    Description: "Required: Intro To Lightning Talks"
     UID: 07b2a8b0860efe7dee9b9eb34b11b7be
     SuccessCriteria:
       - success criteria


### PR DESCRIPTION
Nice catch on the previous PR. 

This one should update the ac2 branch to mark the Intro to Lightning Talks lesson as required