### PR TITLE
Add reminder to submit "N/A" if not presenting a particular unit to all LT submissions

### DIFF
--- a/unit-1-lightning-talks/technical-lightning-talks.md
+++ b/unit-1-lightning-talks/technical-lightning-talks.md
@@ -4,11 +4,11 @@
 
 Your goal is to create and deliver a lightning talk presentation on a given topic! You will be teaching a topic that extends our knowledge! Your audience will be your other cohortmates.
 
-## Requirements about the Presentation
+## Presentation Requirements
 
-Your presentation will be about one of the topics listed below. Follow classroom instructions to get your topic.
+Instructors will share in class or on Slack where to find your topic assignment.
 
-Requirements about your presentation:
+Presentation requirements:
 
 - No more than 5 minutes (Presentations over 5 minutes will be gently cut off)
 - Slides are required (even if it is one slide)
@@ -28,6 +28,7 @@ Finally, before you submit your presentation:
 - Your presentation must be uploaded to the Internet so that instructors can view it
   - We recommend using Google Slides, and setting the sharing permissions to "Anyone on the internet with this link can view"
 - Submit your presentation below
+  - There are pages to submit slides for each unit in Learn. If you are not scheduled to present during a particular unit, please enter "N/A" instead of a URL.
 
 ### Tips
 

--- a/unit-1-lightning-talks/unit-1-submission.md
+++ b/unit-1-lightning-talks/unit-1-submission.md
@@ -9,7 +9,7 @@
 
 ##### !question
 
-Submit the slideshow containing your work on the Unit 1 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view.
+Submit the slideshow containing your work on the Unit 1 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view. If you are not scheduled to present during this unit, please enter "N/A".
 
 ##### !end-question
 

--- a/unit-2-lightning-talks/unit-2-submission.md
+++ b/unit-2-lightning-talks/unit-2-submission.md
@@ -9,7 +9,7 @@
 
 ##### !question
 
-Submit the slideshow containing your work on the Unit 2 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view.
+Submit the slideshow containing your work on the Unit 2 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view. If you are not scheduled to present during this unit, please enter "N/A".
 
 ##### !end-question
 

--- a/unit-3-lightning-talks/unit-3-submission.md
+++ b/unit-3-lightning-talks/unit-3-submission.md
@@ -9,7 +9,7 @@
 
 ##### !question
 
-Submit the slideshow containing your work on the Unit 3 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view.
+Submit the slideshow containing your work on the Unit 3 lightning talk below. Before submitting, ensure that the presentation is available for instructors to view. If you are not scheduled to present during this unit, please enter "N/A".
 
 ##### !end-question
 


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1209513016422676?focus=true)

Changes:
- Add reminder to Technical Lightning Talks lesson and each unit submission page to enter 'N/A' if they are not presenting in that unit
- Technical Lightning Talks lesson: Renames "## Requirements about the Presentation" to "## Presentation Requirements"
- Technical Lightning Talks lesson: Removes sentence "Your presentation will be about one of the topics listed below." that may be confusing since we do not list any of the Unit 1 topics on that page.